### PR TITLE
Update qic.R

### DIFF
--- a/R/qic.R
+++ b/R/qic.R
@@ -88,7 +88,7 @@ QIC.geeglm <- function(object, tol=.Machine$double.eps, ...) {
     # Fit model with independence correlation structure
     object$call$corstr <- "independence"
     object$call$zcor <- NULL
-    model.indep <- eval(object, parent.frame())
+    model.indep <- eval(object$call, parent.frame())
     # model.indep <- update(object, corstr="independence",zcorr=NULL)
 
     # Trace term (penalty for model complexity)


### PR DESCRIPTION
This change fixes a rather critical error in the calculation of QIC where the independence model isn't used because the actual call is not properly updated. The bug was found by Brian McLoone (thanks!)