### PR TITLE
patch geeglm() error when starting values specified

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: geepack
-Version: 1.3.9
+Version: 1.3.10
 Title: Generalized Estimating Equation Package
 Authors@R: c(
     person(given = "Søren", family = "Højsgaard",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# geepack v1.3.10 (2022-09-27)
+
+    * Patch `geeglm()` error when specifying starting values (issue #5).
+	
 # geepack v1.3.9 (2022-08-16)
 
 	* QIC now takes environment argument because the function is called from another function in another package.

--- a/R/geeglm.R
+++ b/R/geeglm.R
@@ -164,7 +164,8 @@ geeglm<- function (formula, family = gaussian, data = parent.frame(),
   mf[[1]] <- as.name("model.frame")
   
   mftmp <- mf
-  to_delete <- c("family", "corstr", "control", "zcor", "std.err", "scale.fix")
+  to_delete <- c("family", "corstr", "control", "zcor", "std.err", "scale.fix",
+                 "start", "etastart", "mustart")
   mftmp[match(to_delete, names(mftmp))] <- NULL
   
   ## mftmp$family <- mftmp$corstr <- mftmp$control <- mftmp$zcor <- mftmp$std.err <- NULL    
@@ -249,9 +250,14 @@ geeglm<- function (formula, family = gaussian, data = parent.frame(),
   xx <- as.data.frame(xx)
   xx[, nacoef] <- NULL
   xx <- as.matrix(xx)
+
+  ## @jeffeaton 2022-09-27: I am not sure if this if(is.null(start)) is desireable.
+  ##    The specified starting values will be used in the initial glm() fit to create
+  ##    glmFit. But here it seems better to use the glmFit coefficients.
+  ##  
+  ## if (is.null(start))
   
-  if (is.null(start)) 
-    start <- glmFit$coef
+  start <- glmFit$coef
    
   ans <- geese.fit(xx, yy, id, offset, soffset, w, waves = waves, 
     zsca, zcor = zcor, corp = NULL, control = control, b = start, 


### PR DESCRIPTION
This PR patches issue #5 that `geeglm()` threw an error when argument `start = ` was specified.

I also suggested one other small change. For the starting values of `geese.fit()`, I removed the condition:

```
  if (is.null(start)) 
    start <- glmFit$coef
```
So that it instead always uses the coefficients from `glmFit` as the starting values for `geese.fit()`
```
  start <- glmFit$coef
```

The specified starting values are still used as starting values for the initial `glm()` fit.  

Maybe I am missing something though about why it reverts back to the initial starting values for initialising `geese.fit()`.

Thanks,
Jeff
